### PR TITLE
xcharter package must be spelled 'XCharter'

### DIFF
--- a/shared/template.tex
+++ b/shared/template.tex
@@ -171,7 +171,7 @@
 
 %% fonts
 \usepackage[charter, expert]{mathdesign}
-\usepackage{xcharter}
+\usepackage{XCharter}
 \usepackage[scaled=.95]{helvet}
 \usepackage[T1]{fontenc} % T1 Schrift Encoding
 \usepackage{textcomp}	 % Zusatzliche Symbole (Text Companion font extension)


### PR DESCRIPTION
This is required to work with MacTeX/TeXLive 2015