### PR TITLE
fix 'synctex' parameter

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,5 +1,5 @@
 #You can add `--interaction nonstopmode` if you don't want pdflatex to stop on errors
-$pdflatex = 'pdflatex -shell-escape -file-line-error --synctex=-1 %O %S';
+$pdflatex = 'pdflatex -shell-escape -file-line-error -synctex=-1 %O %S';
 
 #Use SumatraPDF instead of the default PDF viewer
 $pdf_previewer = 'start "C:\Program Files (x86)\SumatraPDF\SumatraPDF.exe"';


### PR DESCRIPTION
According to latest TeXLive 2015 'pdflatex --help' output:

...
-synctex=NUMBER         generate SyncTeX data for previewers if nonzero
...