### PR TITLE
Titlepage: Properly align examiners and exam date

### DIFF
--- a/shared/titlepage.sty
+++ b/shared/titlepage.sty
@@ -62,13 +62,14 @@
       {Vorgelegt von \par}
       {\large \@author \par}
       {aus \@placeofbirth \par}
-      \vspace{20pt}
-      \begin{TBlist}%
-        \item[Hauptberichter:]\@firstexaminer
-        \item[Mitberichter:]\@secondexaminer
-        \item[Tag der m\"undlichen Pr\"ufung:]\@dateofexamination
-      \end{TBlist}%
-      \vspace{20pt}
+      \vspace{30pt}
+      \begin{tabular}{ll}
+      	\textbf{Hauptberichter:} & \@firstexaminer \\ 
+      	\textbf{Mitberichter:} & \@secondexaminer \\  
+      	&\\
+      	\textbf{Tag der m\"undlichen Pr\"ufung:} & \@dateofexamination
+      \end{tabular} 
+      \vspace{30pt}\par
       {\@department \par}
 	  \vspace{10pt}
 	  {2016}


### PR DESCRIPTION
This commit fixes three violations between the specified design of the titlepage and its implementation in the template:
- there was no blank line between between the examiners and the line with the date of examination
- the date of examination was not properly aligned (TBList does not a sufficient job here)
- the space between the date of examination and the name of the institute was too narrow