### PR TITLE
Replace package "srpage2" with "scrlayer-scrpage" for compatibility with Overleaf

### DIFF
--- a/shared/template.tex
+++ b/shared/template.tex
@@ -272,7 +272,7 @@
 \typearea[current]{last}
 
 %% headers
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 
 \IfElseChapterDefined{%
    \pagestyle{scrheadings} % Seite mit Headern


### PR DESCRIPTION
The package `scrpage2` seems not to be supported in TexLive2020 (and Overleaf) anymore. Therefor, I updated it with the drop-in replacement `scrlayer-scrpage` mentioned by Overleaf [1].

[1] https://www.overleaf.com/blog/tex-live-2020-now-available