### PR TITLE
Add fix preventing footnote numbers resetting per page or chapter

### DIFF
--- a/shared/template.tex
+++ b/shared/template.tex
@@ -337,7 +337,7 @@
    bottom,      % Footnotes appear always on bottom. This is necessary
                 % especially when floats are used
    stable,      % Make footnotes stable in section titles
-   perpage,     % Reset on each page
+   %perpage,     % Reset on each page
    %para,       % Place footnotes side by side of in one paragraph.
    %side,       % Place footnotes in the margin
    ragged,      % Use RaggedRight
@@ -346,6 +346,7 @@
    %symbol,     % use symbols instead of numbers
 ]{footmisc}
 
+\counterwithout{footnote}{chapter} % Continuous numbering of footnotes across chapters
 \interfootnotelinepenalty=10000 % Verhindert das Fortsetzen von
                                 % Fussnoten auf der gegenüberligenden Seite
 


### PR DESCRIPTION
This PR solves issue #24 by commenting the 'perpage' option out and adding a command for continuous numbering across chapters.

Before, the footnote numbers started at 1 per page, which seems unintuitive for a dissertation.
The changes allow a continued numbering across the chapters, i.e., in the overall document.